### PR TITLE
fix: Resolve alembic multiple heads error

### DIFF
--- a/migrations/versions/01b92d7ec7fb_add_activitypub_request_tracking_tables.py
+++ b/migrations/versions/01b92d7ec7fb_add_activitypub_request_tracking_tables.py
@@ -12,7 +12,7 @@ from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision = '01b92d7ec7fb'
-down_revision = 'feef49234599'
+down_revision = '755fa58fd603'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
Fixed the alembic migration chain to resolve the multiple heads error that was preventing database migrations from running.

## Problem
The error "Multiple head revisions are present" occurred because our new migration had the same `down_revision` as an existing migration, creating a fork in the migration history.

## Solution
Updated the `down_revision` in our ActivityPub tracking migration from `feef49234599` to `755fa58fd603` to properly chain it after the `private_mods` migration.

## Test Plan
- [ ] Run `flask db upgrade` to verify migrations work without errors
- [ ] Confirm ActivityPub tracking tables are created correctly

🤖 Generated with [Claude Code](https://claude.ai/code)